### PR TITLE
Add support for HTTP extension-method with body

### DIFF
--- a/relayd/relay_http.c
+++ b/relayd/relay_http.c
@@ -384,6 +384,7 @@ relay_read_http(struct bufferevent *bev, void *arg)
 		case HTTP_METHOD_POST:
 		case HTTP_METHOD_PUT:
 		case HTTP_METHOD_RESPONSE:
+		default:
 			/* HTTP request payload */
 			if (cre->toread > 0)
 				bev->readcb = relay_read_httpcontent;
@@ -393,11 +394,6 @@ relay_read_http(struct bufferevent *bev, void *arg)
 				cre->toread = TOREAD_UNLIMITED;
 				bev->readcb = relay_read;
 			}
-			break;
-		default:
-			/* HTTP handler */
-			cre->toread = TOREAD_HTTP_HEADER;
-			bev->readcb = relay_read_http;
 			break;
 		}
 		if (desc->http_chunked) {


### PR DESCRIPTION
RFC2616 states in chapter 4.3 that:

   The presence of a message-body in a request is signaled by the
   inclusion of a Content-Length or Transfer-Encoding header field in
   the request's message-headers. A message-body MUST NOT be included in
   a request if the specification of the request method (section 5.1.1)
   does not allow sending an entity-body in requests. A server SHOULD
   read and forward a message-body on any request; if the request method
   does not include defined semantics for an entity-body, then the
   message-body SHOULD be ignored when handling the request.

Thus we should not ignore message-body for unknown methods by forcing cre->toread to TOREAD_HTTP_HEADER.

This for example, fixes issues with webdav relaying.
